### PR TITLE
Certs file encoding problem handling, related to #28

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
+gem 'ruby-filemagic'
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.3.2)
+    ruby-filemagic (0.6.1)
     sprockets (2.12.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -102,4 +103,5 @@ DEPENDENCIES
   minitest (~> 5.3)
   rails (~> 4.1.4)
   rake (~> 10.3)
+  ruby-filemagic
   sqlite3 (~> 1.3.9)

--- a/lib/vines/store.rb
+++ b/lib/vines/store.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 module Vines
+  require 'filemagic'
   # An X509 certificate store that validates certificate trust chains.
   # This uses the conf/certs/*.crt files as the list of trusted root
   # CA certificates.
@@ -61,7 +62,9 @@ module Vines
         end
         pairs = files.map do |name|
           begin
-            File.open(name, "r:UTF-8") do |f|
+            fm = FileMagic.new
+            encoding = fm.file(name).split(" ")[0}
+            File.open(name, "r:#{encoding}") do |f|
               pems = f.read.scan(pattern)
               certs = pems.map {|pem| OpenSSL::X509::Certificate.new(pem) }
               certs.reject! {|cert| cert.not_after < Time.now }


### PR DESCRIPTION
Can something like that solve the certs encoding problem ?

`fm.file(name)` returns something like : `UTF-8 Unicode text` for UTF-8 certs and `ASCII text, with no line terminators` for ISO 8859-1.