### PR TITLE
Serve deprected session feature for Xabber client

### DIFF
--- a/lib/vines/stream/client/bind_restart.rb
+++ b/lib/vines/stream/client/bind_restart.rb
@@ -13,6 +13,12 @@ module Vines
           stream.start(node)
           doc = Document.new
           features = doc.create_element('stream:features') do |el|
+            # Session support is deprecated, but like we do it for Adium
+            # in the iq-session-stanza we have to serve the feature for Xabber.
+            # Otherwise it will disconnect after authentication!
+            el << doc.create_element('session', 'xmlns' => NAMESPACES[:session]) do |session|
+              session << doc.create_element('optional')
+            end
             el << doc.create_element('bind', 'xmlns' => NAMESPACES[:bind])
           end
           stream.write(features)


### PR DESCRIPTION
Session support is deprecated, but like we do it for Adium
in the iq-session-stanza we have to serve the feature for Xabber.
Otherwise it will disconnect after authentication!